### PR TITLE
Poll Interval Info(milliseconds->seconds) and Value(500->60) modified

### DIFF
--- a/asus_fanmode.conf
+++ b/asus_fanmode.conf
@@ -16,8 +16,8 @@ mode_silent    = 2
 mode_normal    = 0
 mode_overboost = 1
 
-# Poll interval in milliseconds
-poll = 500
+# Poll interval in seconds
+poll = 60
 
 # High - temperature at which mode is enabled
 # Low  - temperature at which mode switches back


### PR DESCRIPTION
poll interval value `poll` in **asus_fanmode.conf** was set to _500_ (probably assuming it to be milliseconds). But, in **asus_fanmode.cpp** it is being passed to _usleep()_ as _poll * 1000_ which actually makes the time as _poll_ seconds since it is again multiplied by _1000_ to convert milliseconds to seconds. Hence, I've changed the _poll_ value to 60 (i.e. 60 seconds) and the comment is modified to `# Poll interval in seconds`